### PR TITLE
fix oneocr size requirements for PIL images

### DIFF
--- a/oneocr.py
+++ b/oneocr.py
@@ -168,7 +168,15 @@ class OcrEngine:
         '''Process PIL Image object'''
         if image.mode != 'RGBA':
             image = image.convert('RGBA')
-        
+            
+        # oneocr requires minimum 51x51
+        if image.width < 51 or image.height < 51:
+            new_width = max(image.width, 51)
+            new_height = max(image.height, 51)
+            new_img = Image.new("RGBA", (new_width, new_height), (0, 0, 0, 0))
+            new_img.paste(image, ((new_width - image.width) // 2, (new_height - image.height) // 2))
+            image = new_img
+
         # Convert to BGRA format expected by DLL
         b, g, r, a = image.split()
         bgra_image = Image.merge('RGBA', (b, g, r, a))


### PR DESCRIPTION
Snipping Tool/oneocr seems to require a minimum 51 pixel wide AND 51 pixel tall image in order to do any work.

You can see this in action by opening Microsoft Snipping Tool and trying to ocr a really short but long line of text (either vertically or horizontally)

<img width="1186" height="793" alt="image" src="https://github.com/user-attachments/assets/7fd082c0-a103-4291-8a56-363788e12566" />

---

<img width="1186" height="793" alt="image" src="https://github.com/user-attachments/assets/b599741a-6083-42c1-9db3-8bbcd5a9eb76" />


This should maybe be fixed further downstream instead of just for PIL images... But I'm not sure how it all works to be quite honest, and I don't want to go breaking things... this is just the fix I did in my owocr fork.

Took me a while to figure out why sometimes oneocr would just not do anything even though I was giving it a clean image with text.